### PR TITLE
修改 JVM类加载机制篇 笔误

### DIFF
--- a/docs/src/jvm/class-load.md
+++ b/docs/src/jvm/class-load.md
@@ -63,7 +63,7 @@ public class Test {
 
 ### 1）Loading（载入）
 
-JVM 在该阶段的目的是将字节码从不同的数据源（可能是 class 文件、也可能是 jar 包，甚至网络）转化为二进制字节流加载到内存中，并生成一个代表该类的 `java.lang.Class` 对象（在学[反射](https://javabetter.cn/basic-extra-meal/fanshe.html)的时候有讲过）。
+JVM 在该阶段的目的是从不同的数据源（可能是 class 文件、也可能是 jar 包，甚至网络）读取二进制字节流，并加载到内存中。JVM再做一些解析(将字节码解析为方法区中的 类元数据)，最后生成一个代表该类的 `java.lang.Class` 对象（在学[反射](https://javabetter.cn/basic-extra-meal/fanshe.html)的时候有讲过）。
 
 ### 2）Verification（验证）
 


### PR DESCRIPTION
# 文档修正提案：JVM 类加载阶段描述优化

## 问题定位

### 原段落文本
```text
Loading（载入）
JVM 在该阶段的目的是将字节码从不同的数据源（可能是 class 文件、也可能是 jar 包，甚至网络）转化为二进制字节流加载到内存中，并生成一个代表该类的 java.lang.Class 对象（在学反射的时候有讲过）。
```

### 问题分析
#### 核心矛盾
🔴 ​**术语误用**  
原句 "将字节码...转化为二进制字节流" 存在逻辑错误：
- 字节码（`.class` 文件）本质已是**二进制格式**​（可通过 `hexdump` 验证）
- "转化" 操作实际应为 ​**读取二进制流**

🟡 ​**教学误导风险**  
错误表述易使学习者产生误解：虽然可能有点转牛角尖，但此笔误会让我等基础不牢的学生认为class文件不是二进制文件

## 修改提案

### 推荐版本（简洁表述）
```diff
- 转化为二进制字节流加载到内存中
+ 读取二进制字节流，加载到内存中并解析为方法区中的类元数据
```

完整修正：
```text
JVM 在该阶段的目的是从不同数据源（如 class 文件、jar 包或网络）读取二进制字节流，加载到内存中并解析为方法区中的类元数据，最终生成代表该类的 java.lang.Class 对象（反射机制的基础）。
```

### 扩展版本（含技术背景）
```text
JVM 在该阶段的目的是从不同数据源（如 class 文件、jar 包或网络）读取二进制字节流并加载到内存中。该字节流随后被解析为方法区中的类元数据（如常量池、字段/方法表等），最终生成一个代表该类的 java.lang.Class 对象。

技术背景：
1. 二进制流 (Binary Stream)
   - 定义：以字节为单位的连续数据序列（如 .exe、.jpg、网络报文）
   - 特性：无需编码转换，适合机器直接处理
   - 来源：文件系统、网络传输、内存动态生成（如 Spring 动态代理）

2. 文本流 vs 二进制流
   | 维度         | 文本流                     | 二进制流                  |
   |--------------|---------------------------|--------------------------|
   | 存储单位     | 字符（需编码，如 UTF-8）   | 字节                     |
   | 换行符处理   | 自动转换（如 \r\n → \n）  | 无转换                   |
   | 典型场景     | 配置文件、日志            | 可执行文件、图片、字节码 |

```


### 文档一致性
与 Oracle 官方文档描述对齐：
> "The Class Loader reads the class file (a byte stream), parses it..."  
> —— [Oracle JVM Spec](https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-5.html)